### PR TITLE
monit calling delayed_job without wrapper script

### DIFF
--- a/roles/common/templates/monit.j2
+++ b/roles/common/templates/monit.j2
@@ -1,9 +1,9 @@
 check process openfoodnetwork_dj_worker_0
 with pidfile {{ current_path }}/tmp/pids/delayed_job.0.pid
-start program = "/bin/bash -c 'RAILS_ENV={{ rails_env }} {{ current_path }}/script/delayed_job.sh -i 0 start'"
+start program = "/bin/bash -c 'RAILS_ENV={{ rails_env }} {{ unicorn_home_path }}/.rbenv/shims/ruby {{ current_path }}/script/delayed_job -i 0 start'"
 as uid {{ user }} and gid {{ user }}
 with timeout 120 seconds
-stop program = "/bin/bash -c 'RAILS_ENV={{ rails_env }} {{ current_path }}/script/delayed_job.sh -i 0 stop'"
+stop program = "/bin/bash -c 'RAILS_ENV={{ rails_env }} {{ unicorn_home_path }}/.rbenv/shims/ruby {{ current_path }}/script/delayed_job -i 0 stop'"
 as uid {{ user }} and gid {{ user }}
 with timeout 120 seconds
 if mem is greater than 250.0 MB for 3 cycles then restart


### PR DESCRIPTION
This change of the monit config file should make the wrapper script `delayed_job.sh` obsolete.

@RohanM Can you check this on your local machine? I changed our servers and they started dj without problems. But I couldn't test the deployment (still need memory).